### PR TITLE
Fixing repeat payment shipping address and recipient

### DIFF
--- a/src/Request/CreateRepeatPayment.php
+++ b/src/Request/CreateRepeatPayment.php
@@ -72,8 +72,12 @@ class CreateRepeatPayment extends AbstractRequest
         $this->vendorTxCode = $vendorTxCode;
         $this->amount = $amount;
 
-        $this->shippingAddress = $shippingAddress->withFieldPrefix($this->shippingAddressFieldPrefix);
-        $this->shippingRecipient = $shippingRecipient->withFieldPrefix($this->shippingNameFieldPrefix);
+        if (isset($shippingAddress)) {
+            $this->shippingAddress = $shippingAddress->withFieldPrefix($this->shippingAddressFieldPrefix);
+        }
+        if (isset($shippingRecipient)) {
+            $this->shippingRecipient = $shippingRecipient->withFieldPrefix($this->shippingNameFieldPrefix);
+        }
 
         // Additional options.
         $this->setOptions($options);


### PR DESCRIPTION
Fixes and issue with creating a repeat payment when no shippingAddress and shippingRecipient is provided.

Added checks that the shippingAddress and shippingRecipient are set so the withFieldPrefix can be called. 