### PR TITLE
Compatability for php8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+
+vendor
+.phpunit.result.cache
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
  
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
- 
+  - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
+
 before_script:
   - composer self-update
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "guzzlehttp/guzzle": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.0"
+        "phpunit/phpunit": "^9.6",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="SagePay Pi Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Request/AbstractInstruction.php
+++ b/src/Request/AbstractInstruction.php
@@ -33,6 +33,7 @@ abstract class AbstractInstruction extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $body = [];

--- a/src/Request/CreateCardIdentifier.php
+++ b/src/Request/CreateCardIdentifier.php
@@ -101,6 +101,7 @@ class CreateCardIdentifier extends AbstractRequest
      * Replace all card detail characters with asterisks.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = $this->jsonSerializePeek();

--- a/src/Request/CreatePayment.php
+++ b/src/Request/CreatePayment.php
@@ -328,6 +328,7 @@ class CreatePayment extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         // The mandatory fields.

--- a/src/Request/CreateRefund.php
+++ b/src/Request/CreateRefund.php
@@ -115,6 +115,7 @@ class CreateRefund extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         // The mandatory fields.

--- a/src/Request/CreateRelease.php
+++ b/src/Request/CreateRelease.php
@@ -34,6 +34,7 @@ class CreateRelease extends AbstractInstruction
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $body = parent::jsonSerialize();

--- a/src/Request/CreateRepeatPayment.php
+++ b/src/Request/CreateRepeatPayment.php
@@ -185,6 +185,7 @@ class CreateRepeatPayment extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         // The mandatory fields.

--- a/src/Request/CreateSecure3D.php
+++ b/src/Request/CreateSecure3D.php
@@ -44,6 +44,7 @@ class CreateSecure3D extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Request/CreateSessionKey.php
+++ b/src/Request/CreateSessionKey.php
@@ -27,6 +27,7 @@ class CreateSessionKey extends AbstractRequest
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Request/FetchInstructions.php
+++ b/src/Request/FetchInstructions.php
@@ -15,6 +15,7 @@ class FetchInstructions extends AbstractInstruction
      * Get the message body data for serializing.
      * There is no body data for this message.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
     }

--- a/src/Request/FetchSessionKey.php
+++ b/src/Request/FetchSessionKey.php
@@ -50,6 +50,7 @@ class FetchSessionKey extends AbstractRequest
     /**
      * This message has no body.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
     }

--- a/src/Request/FetchTransaction.php
+++ b/src/Request/FetchTransaction.php
@@ -40,6 +40,7 @@ class FetchTransaction extends AbstractRequest
      * Get the message body data for serializing.
      * There is no body data for this message.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
     }

--- a/src/Request/LinkSecurityCode.php
+++ b/src/Request/LinkSecurityCode.php
@@ -69,6 +69,7 @@ class LinkSecurityCode extends AbstractRequest
      * Get the message body data for serializing.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [

--- a/src/Request/Model/Address.php
+++ b/src/Request/Model/Address.php
@@ -124,6 +124,7 @@ class Address implements AddressInterface
      *
      * @return array Data for passing to the API, requiring JSON conversion first.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [

--- a/src/Request/Model/Person.php
+++ b/src/Request/Model/Person.php
@@ -79,6 +79,7 @@ class Person implements PersonInterface
     /**
      * @return array The Person returned as an array for the API, requiring conversion to JSON
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         // First/last name is always required.

--- a/src/Request/Model/ReusableCard.php
+++ b/src/Request/Model/ReusableCard.php
@@ -55,6 +55,7 @@ class ReusableCard extends AbstractCard
      * Return the complete object data for serialized storage.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $message = [

--- a/src/Request/Model/ReusableCvvCard.php
+++ b/src/Request/Model/ReusableCvvCard.php
@@ -30,6 +30,7 @@ class ReusableCvvCard extends SingleUseCard
      * Return the complete object data for serialized storage.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $message = [

--- a/src/Request/Model/SingleUseCard.php
+++ b/src/Request/Model/SingleUseCard.php
@@ -79,6 +79,7 @@ class SingleUseCard extends AbstractCard
      * Return the complete object data for serialized storage.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $message = [

--- a/src/Response/AbstractInstruction.php
+++ b/src/Response/AbstractInstruction.php
@@ -44,6 +44,7 @@ abstract class AbstractInstruction extends AbstractResponse
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Response/AbstractTransaction.php
+++ b/src/Response/AbstractTransaction.php
@@ -294,6 +294,7 @@ abstract class AbstractTransaction extends AbstractResponse
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [];

--- a/src/Response/CardIdentifier.php
+++ b/src/Response/CardIdentifier.php
@@ -103,6 +103,7 @@ class CardIdentifier extends AbstractResponse
      * Reduce the object to an array so it can be serialised and stored between pages.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Response/ErrorCollection.php
+++ b/src/Response/ErrorCollection.php
@@ -123,6 +123,7 @@ class ErrorCollection extends AbstractCollection
      * Reduce the object to an array so it can be serialised.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [

--- a/src/Response/InstructionCollection.php
+++ b/src/Response/InstructionCollection.php
@@ -42,6 +42,7 @@ class InstructionCollection extends AbstractCollection
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Response/Model/Amount.php
+++ b/src/Response/Model/Amount.php
@@ -112,6 +112,7 @@ class Amount implements JsonSerializable
      * Serialisation for storage/logging/debug.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getData();

--- a/src/Response/Model/AvsCvcCheck.php
+++ b/src/Response/Model/AvsCvcCheck.php
@@ -152,6 +152,7 @@ class AvsCvcCheck implements JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getData();

--- a/src/Response/Model/Card.php
+++ b/src/Response/Model/Card.php
@@ -128,6 +128,7 @@ class Card implements JsonSerializable
      * Serialisation for storage.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getData();

--- a/src/Response/Model/Error.php
+++ b/src/Response/Model/Error.php
@@ -209,6 +209,7 @@ class Error implements JsonSerializable
      * Reduce the object to an array so it can be serialised.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [

--- a/src/Response/NoContent.php
+++ b/src/Response/NoContent.php
@@ -20,6 +20,7 @@ class NoContent extends AbstractResponse
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [];

--- a/src/Response/Secure3D.php
+++ b/src/Response/Secure3D.php
@@ -61,6 +61,7 @@ class Secure3D extends AbstractResponse
      * Convenient serialisation for logging and debugging.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = [];

--- a/src/Response/Secure3DRedirect.php
+++ b/src/Response/Secure3DRedirect.php
@@ -84,6 +84,7 @@ class Secure3DRedirect extends AbstractTransaction
      * Convenient serialisation for logging and debugging.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $return = parent::jsonSerialize();

--- a/src/Response/SessionKey.php
+++ b/src/Response/SessionKey.php
@@ -122,6 +122,7 @@ class SessionKey extends AbstractResponse
      * Reduce the object to an array so it can be serialised.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Security/SensitiveValue.php
+++ b/src/Security/SensitiveValue.php
@@ -64,6 +64,7 @@ final class SensitiveValue implements Serializable, JsonSerializable
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
     }

--- a/src/ServerRequest/Secure3DAcs.php
+++ b/src/ServerRequest/Secure3DAcs.php
@@ -41,6 +41,7 @@ class Secure3DAcs extends AbstractServerRequest
      * Only needed for debugging or logging.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/tests/Request/Model/AddressTest.php
+++ b/tests/Request/Model/AddressTest.php
@@ -2,9 +2,10 @@
 
 namespace Academe\SagePay\Psr7\Request\Model;
 
-//use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     protected $simpleGB = [
         'address1' => 'Address1',
@@ -96,81 +97,65 @@ class AddressTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMissingAddress1()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         unset($data['address1']);
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMissingCity()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         unset($data['city']);
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMissingCountry()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         unset($data['country']);
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMissingState()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         unset($data['state']);
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testInvalidState()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         $data['state'] = 'XX';
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testInvalidCountry()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         $data['country'] = 'XX';
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testUnexpectedState()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleGB;
         $data['state'] = 'AL';
         $address = Address::fromData($data);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMissingPostalCode()
     {
+        $this->expectException(UnexpectedValueException::class);
         $data = $this->simpleUS;
         unset($data['postalCode']);
         $address = Address::fromData($data);
@@ -181,6 +166,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingPostalCodeIE()
     {
+        $this->expectNotToPerformAssertions();
         $data = $this->simpleGB;
         $data['country'] = 'IE';
 


### PR DESCRIPTION
- Add `#[\ReturnTypeWillChange]` to jsonSerialize  to suppress notice of `PHP Deprecated:  Return type of Academe\SagePay\Psr7\Request\Model\Address::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
- Upgrade phpunit and travis config to match php versions in composer.json